### PR TITLE
Major fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.6.0 - Major
+* Fixed keywords `and`, `in`, `is`, `not` and `or` not being highlighted (classes "keyword" and "operator" don't mix)
+* Fixed `class` not being highlighted properly
+* Added highlighting to functions, methods and properties
+* Added highlighting to select few standard functions (print, set_*, get_*). Does not work with methods yet.
+* Now indents whenever a line of code ends with `:` (i.e. after declaring a function or a class)
+
+## 2.5.0 - Minor
+* Added keywords `onready` and `breakpoint`
+* Removed debug statements
+
 ## 2.4.0 - Minor
 * Added ability to disable the completions
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Converted from the sublime text grammar: https://github.com/beefsack/GDScript-su
 - [DONE] Fix Comments
 - [DONE] ~~Remove~~ Reduce Duplicates
 - [DONE] Reduce Precedence
-- [DONE] Turn Off Exclude Lower Precedenc
+- [DONE] Turn Off Exclude Lower Precedence
 - [DONE] Add Classes to completions (totally forgot)
 - [DONE] Add class extends snippet (as clex)
 - [DONE] Disable .variable.other.gdscript
 - [DONE] Add scope of class/method/constant/signal to right label
+- [DONE] Correct some of the entities that won't highlight individual pieces (typing `class` won't highlight until you have `class Name:`)
+- [] add the other support functions (this is going give a long, *long* list)
 - [] follow grammar guidelines more strictly
-- [] correct some of the entities that won't highlight individual pieces (typing `class` won't highlight until you have `class Name:`)

--- a/grammars/gdscript.cson
+++ b/grammars/gdscript.cson
@@ -21,11 +21,11 @@ patterns: [
     name: "punctuation.definition.comment.gdscript"
   }
   {
-    match: "\\b(?i:elif|else|for|if|while|break|continue|pass|return|onready|breakpoint)\\b"
-    name: "keyword.control.flow.gdscript"
+    match: "\\b(?i:elif|else|for|if|while|break|continue|pass|and|in|is|not|or|return|onready|breakpoint)\\b"
+    name: "keyword.control.gdscript"
   }
   {
-    match: "\\b(?i:&&|and|in|is|!|not|\\|\\||or)\\b"
+    match: "\\b(&&|!|\\|\\|)\\b"
     name: "keyword.operator.logical.gdscript"
   }
   {
@@ -41,7 +41,7 @@ patterns: [
     name: "keyword.operator.assignment.gdscript"
   }
   {
-    match: "\\b(?i:extends|assert)\\b"
+    match: "\\b(?i:class|extends|assert)\\b"
     name: "keyword.other.gdscript"
   }
   {
@@ -60,6 +60,18 @@ patterns: [
     match: "\\bvar\\b"
     name: "storage.type.var.gdscript"
   }
+  { # Standard functions
+    match: '(?<![^.]\\.|:)\\b(print|set_\\w+|get_\\w+)\\b(?=(\\()([^)]*)(\\)))'
+    name: 'support.function.library.gdscript'
+  }
+  { # Function call
+    match: '\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[(]))'
+    name: 'support.function.any-method.gdscript'
+  }
+  { # Object property
+    match: '(?<=[^.]\\.)\\b([A-Za-z_]\\w*)\\b(?![(])'
+    name: 'variable.other.gdscript'
+  }
 
 #------------------------------------------
   #  Captures
@@ -68,10 +80,8 @@ patterns: [
   {
     captures:
       "1":
-        name: "storage.type.class.gdscript"
-      "2":
         name: "entity.name.type.class.gdscript"
-    match: "^\\s*(?i:(class))\\s+([a-zA-Z_][a-zA-Z_0-9]*)\\s*:"
+    match: "(?<=^class)\\s+([a-zA-Z_]\\w*)\\s*(?=:)"
   }
   {
     captures:
@@ -87,7 +97,7 @@ patterns: [
         name: "entity.name.type.instance"
       "2":
         name: "keyword.operator.new"
-    match: "\\b(\\w+)(?i:\\.)(new)"
+    match: "\\b(\\w+)(\\.)(new)"
   }
 
 #------------------------------------------
@@ -95,7 +105,7 @@ patterns: [
 #------------------------------------------
 
   {
-    begin: "^\\s*(?i:(func))\\s+([a-zA-Z_][a-zA-Z_0-9]*)\\s*\\("
+    begin: "^\\s*(?i:(func))\\s+([a-zA-Z_]\\w*)\\s*\\("
     beginCaptures:
       "1":
         name: "storage.type.function.gdscript"
@@ -110,11 +120,11 @@ patterns: [
     ]
   }
   {
-    begin: "[.]([\\w][a-zA-Z_0-9]*)\\s*\\("
+    begin: "[.]([\\w]\\w*)\\s*\\("
     # Makes method names blue
-    # beginCaptures:
-    #   "1":
-    #     name: "entity.name.function.gdscript"
+    beginCaptures:
+       "1":
+         name: "entity.name.function.gdscript"
     end: "\\)"
     patterns: [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lang-gdscript",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GDScript (Godot Scripting Language) grammar and completions for atom.io.",
   "main": "./lib/main",
   "keywords": [

--- a/settings/lang-gdscript.cson
+++ b/settings/lang-gdscript.cson
@@ -1,3 +1,4 @@
 '.source.gdscript':
     'editor':
         'commentStart': '# '
+        'increaseIndentPattern': '\\:.*$'


### PR DESCRIPTION
Changes:
* Fixed keywords `and`, `in`, `is`, `not` and `or` not being highlighted (classes "keyword" and "operator" don't mix)
* Fixed `class` not being highlighted properly
* Added highlighting to functions, methods and properties
* Added highlighting to select few standard functions (print, set_\*, get_\*). Does not work with methods yet.
* Now indents next line whenever a line of code ends with `:` (i.e. after declaring a function or a class)