### PR TITLE
add tscn to fileTypes

### DIFF
--- a/grammars/gdscript.cson
+++ b/grammars/gdscript.cson
@@ -1,4 +1,4 @@
-fileTypes: [ "gd" ]
+fileTypes: [ "gd", "tscn" ]
 scopeName: "source.gdscript"
 name: "GDScript (Godot Engine)"
 patterns: [


### PR DESCRIPTION
I'm not sure if tscn is technically GDScript, but I'm always applying this syntax when I work with them. Everything looks right, and they are certainly easier to read.

BTW, thanks for your hard work.